### PR TITLE
Reduce brightness of primary color in dark mode

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -33,8 +33,8 @@
     --card-foreground: 0 0% 98%;
     --popover: 240 10% 3.9%;
     --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 240 5.9% 10%;
+    --primary: 240 5% 25%;
+    --primary-foreground: 0 0% 98%;
     --secondary: 240 3.7% 15.9%;
     --secondary-foreground: 0 0% 98%;
     --muted: 240 3.7% 15.9%;


### PR DESCRIPTION
- Change primary color from bright white (98%) to muted gray (25%)
- Fixes overly bright "Convert to ASCII" button in dark mode
- Fixes overly bright selected format option in bottom right panel
- Provides better contrast and reduces eye strain in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)