### PR TITLE
Add mobile-responsive layout with editor/results toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { Select } from '@/components/ui/select'
-import { Loader2, Settings, ChevronDown, ChevronUp, Moon, Sun } from 'lucide-react'
+import { Loader2, Settings, ChevronDown, ChevronUp, Moon, Sun, Code, Eye } from 'lucide-react'
 import './App.css'
 
 // Example graphs
@@ -76,6 +76,8 @@ function App() {
   const [outputFormat, setOutputFormat] = useState<OutputFormat>('ascii')
   const [formatPanelOpen, setFormatPanelOpen] = useState(false)
   const [isDarkMode, setIsDarkMode] = useState(false)
+  const [mobileView, setMobileView] = useState<'editor' | 'results'>('editor')
+  const [isMobile, setIsMobile] = useState(window.innerWidth < 768)
   const modulesLoadedRef = useRef(false)
 
   // Initialize Perl modules
@@ -226,6 +228,16 @@ function App() {
     }
   }, [isDarkMode])
 
+  // Handle window resize to update isMobile state
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth < 768)
+    }
+
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
+
   // Auto-convert when input changes (debounced)
   useEffect(() => {
     if (loadingState !== 'ready' || !input.trim()) return
@@ -368,8 +380,10 @@ END_INPUT
 
   return (
     <div className="h-screen w-screen overflow-hidden bg-background font-sans">
-      {/* Output - Full screen background */}
-      <div className="absolute inset-0 flex items-center justify-center p-8">
+      {/* Output - Full screen background, responsive */}
+      <div className={`absolute inset-0 flex items-center justify-center p-4 md:p-8 ${
+        mobileView === 'editor' ? 'hidden md:flex' : 'flex'
+      }`}>
         {loadingState === 'ready' && output ? (
           outputFormat === 'html' || outputFormat === 'svg' ? (
             <div
@@ -377,24 +391,26 @@ END_INPUT
               dangerouslySetInnerHTML={{ __html: output }}
             />
           ) : (
-            <pre className="font-mono text-sm leading-relaxed text-foreground/90 select-text">
+            <pre className="font-mono text-xs md:text-sm leading-relaxed text-foreground/90 select-text">
               {output}
             </pre>
           )
         ) : loadingState === 'ready' && !output ? (
           <div className="text-center text-muted-foreground">
-            <p className="text-lg">Enter graph notation to see output</p>
+            <p className="text-base md:text-lg">Enter graph notation to see output</p>
           </div>
         ) : null}
       </div>
 
-      {/* Input Pane - Floating, resizable, top-left */}
+      {/* Input Pane - Full screen on mobile, floating on desktop */}
       <div
-        className="absolute top-8 left-8 bg-card border border-border rounded-lg shadow-2xl flex flex-col overflow-hidden transition-shadow duration-200 hover:shadow-3xl"
-        style={{
+        className={`bg-card border border-border flex flex-col overflow-hidden transition-shadow duration-200 ${
+          mobileView === 'results' ? 'hidden md:flex' : 'flex'
+        } fixed inset-0 md:absolute md:top-8 md:left-8 md:rounded-lg md:shadow-2xl md:hover:shadow-3xl md:inset-auto`}
+        style={!isMobile ? {
           width: `${paneWidth}px`,
           height: `${paneHeight}px`,
-        }}
+        } : {}}
       >
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-border bg-muted/30">
@@ -464,17 +480,17 @@ END_INPUT
           </Button>
         </div>
 
-        {/* Resize handles */}
+        {/* Resize handles - Desktop only */}
         <div
-          className="absolute right-0 top-0 bottom-0 w-1 cursor-ew-resize hover:bg-primary/20 transition-colors"
+          className="hidden md:block absolute right-0 top-0 bottom-0 w-1 cursor-ew-resize hover:bg-primary/20 transition-colors"
           onMouseDown={() => setIsDragging('width')}
         />
         <div
-          className="absolute left-0 right-0 bottom-0 h-1 cursor-ns-resize hover:bg-primary/20 transition-colors"
+          className="hidden md:block absolute left-0 right-0 bottom-0 h-1 cursor-ns-resize hover:bg-primary/20 transition-colors"
           onMouseDown={() => setIsDragging('height')}
         />
         <div
-          className="absolute right-0 bottom-0 w-4 h-4 cursor-nwse-resize hover:bg-primary/20 transition-colors rounded-tl-sm"
+          className="hidden md:block absolute right-0 bottom-0 w-4 h-4 cursor-nwse-resize hover:bg-primary/20 transition-colors rounded-tl-sm"
           onMouseDown={() => {
             setIsDragging('width')
             // Also enable height dragging
@@ -483,8 +499,8 @@ END_INPUT
         />
       </div>
 
-      {/* Dark Mode Toggle - Top Right */}
-      <div className="absolute top-8 right-8">
+      {/* Dark Mode Toggle - Top Right on desktop, top right on mobile */}
+      <div className="absolute top-4 right-4 md:top-8 md:right-8 z-10">
         <Button
           onClick={() => setIsDarkMode(!isDarkMode)}
           size="sm"
@@ -500,8 +516,10 @@ END_INPUT
         </Button>
       </div>
 
-      {/* Format Selector Panel - Bottom Right */}
-      <div className="absolute bottom-8 right-8">
+      {/* Format Selector Panel - Bottom Right on desktop, hidden on mobile when editor is shown */}
+      <div className={`absolute bottom-20 right-4 md:bottom-8 md:right-8 ${
+        mobileView === 'editor' ? 'hidden md:block' : 'block'
+      }`}>
         <div className="bg-card border border-border rounded-lg shadow-2xl overflow-hidden transition-all duration-200">
           {/* Collapsed header */}
           {!formatPanelOpen && (
@@ -562,6 +580,30 @@ END_INPUT
               </div>
             </div>
           )}
+        </div>
+      </div>
+
+      {/* Mobile View Toggle - Bottom Center (Mobile Only) */}
+      <div className="md:hidden fixed bottom-4 left-1/2 transform -translate-x-1/2 z-50">
+        <div className="bg-card border border-border rounded-lg shadow-2xl overflow-hidden flex">
+          <Button
+            onClick={() => setMobileView('editor')}
+            size="sm"
+            variant={mobileView === 'editor' ? 'default' : 'ghost'}
+            className="rounded-r-none px-6 py-6"
+          >
+            <Code className="h-5 w-5 mr-2" />
+            Editor
+          </Button>
+          <Button
+            onClick={() => setMobileView('results')}
+            size="sm"
+            variant={mobileView === 'results' ? 'default' : 'ghost'}
+            className="rounded-l-none px-6 py-6"
+          >
+            <Eye className="h-5 w-5 mr-2" />
+            Results
+          </Button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- Add toggle button to switch between editor and results on mobile
- Make editor full-screen on mobile devices (< 768px)
- Hide resize handles on mobile (not applicable for touch)
- Adjust UI positioning for mobile (dark mode toggle, format panel)
- Keep floating layout on desktop with resizable panes
- Automatically detect screen size and adjust layout accordingly

On mobile:
- Editor and results views are mutually exclusive
- Toggle button at bottom center switches between views
- Full-screen layout for better usability

On desktop:
- Original floating editor pane in top-left
- Full-screen results in background
- All original functionality preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)