### PR TITLE
Move output type selector to top in mobile responsive mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -690,8 +690,8 @@ END_INPUT
         </Button>
       </div>
 
-      {/* Format Selector Panel - Bottom Right on desktop, hidden on mobile when editor is shown */}
-      <div className={`absolute bottom-20 right-4 md:bottom-8 md:right-8 ${
+      {/* Format Selector Panel - Top on mobile, Bottom Right on desktop, hidden on mobile when editor is shown */}
+      <div className={`absolute top-4 right-4 md:top-auto md:bottom-8 md:right-8 ${
         mobileView === 'editor' ? 'hidden md:block' : 'block'
       }`}>
         <div className="bg-card border border-border rounded-lg shadow-2xl overflow-hidden transition-all duration-200">


### PR DESCRIPTION
The output format selector has been repositioned to improve mobile UX:
- Mobile: Now at top-right (top-4 right-4)
- Desktop: Remains at bottom-right (bottom-8 right-8)

This makes the selector more accessible on mobile devices where it was previously hidden at the bottom of the viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)