### PR TITLE
Update workflow to deploy from main branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - claude/reduce-network-example-011CUPWYabckgj69e7cY9Zb4
+      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Changed GitHub Pages deployment workflow to trigger on pushes to the main branch instead of the feature branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)