### PR TITLE
Fix graph alignment to center when fit button is clicked

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -589,15 +589,10 @@ END_INPUT
     const scaleY = containerHeight / contentHeight
     const newZoom = Math.min(scaleX, scaleY, 1) // Don't zoom in beyond 100%
 
-    // Center the content
-    const scaledWidth = contentWidth * newZoom
-    const scaledHeight = contentHeight * newZoom
-    const newPanX = (containerWidth - scaledWidth) / 2 / newZoom
-    const newPanY = (containerHeight - scaledHeight) / 2 / newZoom
-
+    // Reset pan to center (flexbox centering handles the actual centering)
     setZoom(newZoom)
-    setPanX(newPanX)
-    setPanY(newPanY)
+    setPanX(0)
+    setPanY(0)
   }
 
   // Handle resize dragging


### PR DESCRIPTION
The fit button was causing the graph to align to the right instead of centering. The issue was that the container already uses flexbox centering (flex items-center justify-center), but the fit function was calculating additional pan offsets, causing double-centering and misalignment.

Fixed by resetting pan to 0 when fitting, allowing flexbox to handle the centering properly.