### PR TITLE
Fix Dataset Display Scaling Issue

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -626,6 +626,8 @@ function App() {
     if (example) {
       setInput(example.graph)
       // Let the auto-convert useEffect handle the conversion to avoid race conditions
+      // Fit to view after a short delay to ensure conversion completes
+      setTimeout(() => handleFitToView(), 700)
     }
   }
 
@@ -636,7 +638,10 @@ function App() {
     // Re-convert with new engine
     if (loadingState === 'ready' && input.trim()) {
       setIsConverting(true)
-      convertGraph(undefined, engine)
+      convertGraph(undefined, engine).then(() => {
+        // Fit to view after conversion completes
+        setTimeout(() => handleFitToView(), 100)
+      })
     }
   }
 


### PR DESCRIPTION
Previously, when users selected a new example from the dropdown or changed the conversion engine, the graph would render but wouldn't automatically fit to the viewport. Users had to manually click the "Fit to view" button.

This change adds automatic fit-to-view in two scenarios:
- When selecting a new example from the dropdown (700ms delay)
- When changing the conversion engine (100ms delay after conversion)

The delays ensure the graph has fully rendered before calculating the fit-to-view dimensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)